### PR TITLE
Add a closure version for simple use in JSX.

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -1,0 +1,2 @@
+import closure from './src/closure';
+export default closure;

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,0 +1,9 @@
+import openLoginPopup from './feathers-authentication-popups';
+
+// Allows simple registration as an event handler. ie. onClick={openLoginPopup(url)}
+export default function (url) {
+  return function (event) {
+    event.preventDefault();
+    return openLoginPopup(url);
+  };
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,12 +7,28 @@ global.window = {
 
 import { expect } from 'chai';
 import openLoginPopup, {authAgent, getCenterCoordinates} from '../src/feathers-authentication-popups';
+import clickHandler from '../src/handler';
 import EventEmitter from 'events';
 
 describe('Client Utils', () => {
   describe('OAuth Popup', () => {
     it(`opens new window`, () => {
       let authWindow = openLoginPopup('/auth/github');
+      expect(authWindow).to.not.equal(undefined);
+    });
+  });
+
+  describe('Closure / Click Handler Version', () => {
+    it(`returns a function`, () => {
+      expect(typeof clickHandler).to.equal('function');
+      expect(typeof clickHandler('/auth/github')).to.equal('function');
+    });
+
+    it(`opens new window`, () => {
+      let event = {
+        preventDefault () {}
+      };
+      let authWindow = clickHandler('/auth/github')(event);
       expect(authWindow).to.not.equal(undefined);
       global.window = oldWindow;
     });


### PR DESCRIPTION
You can now use this directly in a jsx file:

```js
import React from 'react';
import openLoginPopup from 'feathers-authentication-popups/handler';

const Button = ({url, popup}) => {
  return (
    <a href={url} onClick={popup ? openPopup(url) : null} >Login</a>
  );
};

export default Button;
```